### PR TITLE
Fix pathnames for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,8 +148,11 @@ export default (options = {}) => {
 
                     return orgName
                 })
-
+                
                 const uniquePaths = paths.filter(p => p !== null)
+
+                // On Windows node-sass requires imports to be C:\/test.scss instead of C:\test.scss 
+                uniquePaths = uniquePaths.map(path=>path.replace(/\\/g,'\/'));
 
                 if (uniquePaths.length) {
                     return `@import ${uniquePaths.join(', ')};`


### PR DESCRIPTION
collect-sass current dont work if its used on a Windows machine cause node-sass can not find the files.

In example: If the resolved diretory of a scss file is `C:\dir\test.scss` on windows, then node-sass complains that it can not found the file `Cdirtest.scss`. But If we replace the \ with \/ node-sass works fine.

I tried to add a test case for that. But I was not even able to get the current tests to pass. There seems to be a few things broken and I currently have not the time to repair that. Sorry.

Sidenote: The problem are especially the absolute @imports in node-sass